### PR TITLE
Add production build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Agent Flow is a modular, extensible agent platform inspired by modern no-code an
 3. **Open your browser:**
    Visit [http://localhost:3000](http://localhost:3000) to see the app.
 
+## Production Build
+
+Run the following commands to create a production build and serve it:
+
+```bash
+npm run build
+npm start
+```
+
+`npm start` serves the prebuilt Next.js application.
+
 ## Project Structure
 
 - `app/` – Main application code (pages, api routes)


### PR DESCRIPTION
## Summary
- add instructions for production build and mention `npm start` purpose

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470526950483259eff8db296503984